### PR TITLE
Type missmatch for std::max

### DIFF
--- a/include/cppoptlib/problem.h
+++ b/include/cppoptlib/problem.h
@@ -80,7 +80,7 @@ class Problem {
     gradient(x, actual_grad);
     finiteGradient(x, expected_grad, accuracy);
     for (TIndex d = 0; d < D; ++d) {
-      Scalar scale = std::max((std::max(fabs(actual_grad[d]), fabs(expected_grad[d]))), 1.);
+      Scalar scale = std::max(static_cast<Scalar>(std::max(fabs(actual_grad[d]), fabs(expected_grad[d]))), Scalar(1.));
       if(fabs(actual_grad[d]-expected_grad[d])>1e-2 * scale)
         return false;
     }


### PR DESCRIPTION
std::max is a template function that its parameters are the same type. The problem class is a template class, but if float type is used, there is call to std::max where float and double are compared since a double literal is used there. Fixed with static_cast as already done several lines below that bug.